### PR TITLE
Ergonomics

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,8 @@ env_logger = "^0.11.3"
 
 tokio = { version = "^1.37.0", features = ["full"], optional = true }
 xkeysym = "0.2.0"
+bitbybit = "1.3.2"
+arbitrary-int = "1.2.7"
 
 [build-dependencies]
 built = { version = "^0.7.2" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ zbus = { version = "^4.2.0", default-features = false }
 env_logger = "^0.11.3"
 
 tokio = { version = "^1.37.0", features = ["full"], optional = true }
+xkeysym = "0.2.0"
 
 [build-dependencies]
 built = { version = "^0.7.2" }

--- a/src/ibus/engine.rs
+++ b/src/ibus/engine.rs
@@ -14,7 +14,18 @@ use super::{ibus_serde::make_ibus_text, IBusModifierState, LookupTable};
 /// Your implementation can use the methods of the [`IBusEngineBackend`]
 /// to display text to the user.
 pub trait IBusEngine: Send + Sync {
-    /// 键盘按键消息
+    /// A key was pressed or released.
+    ///
+    /// `keyval` encodes the symbol of the key interpreted according to the current keyboard layout.
+    ///
+    /// `keycode` encodes the position of the key on the keyboard, which is independent of the
+    /// keyboard layout.
+    ///
+    /// state encodes wether the key was pressed or released, and modifiers (shift, control...).
+    ///
+    /// Note that when `shift+a` is pressed, `keyval` will be `Keysym::A` (instead of `Keysym::a`).
+    /// `state.shift()` will still be `true`. Same applies for `AltGr` in keyboard layouts which
+    /// have it.
     fn process_key_event(
         &mut self,
         _sc: SignalContext<'_>,

--- a/src/ibus/engine.rs
+++ b/src/ibus/engine.rs
@@ -7,7 +7,7 @@ use log::info;
 use xkeysym::{KeyCode, Keysym};
 use zbus::{fdo, interface, zvariant::Value, Connection, SignalContext};
 
-use super::{ibus_serde::make_ibus_text, LookupTable};
+use super::{ibus_serde::make_ibus_text, IBusModifierState, LookupTable};
 
 /// Implement this trait to implement an input method
 ///
@@ -20,7 +20,7 @@ pub trait IBusEngine: Send + Sync {
         _sc: SignalContext<'_>,
         _keyval: Keysym,
         _keycode: KeyCode,
-        _state: u32,
+        _state: IBusModifierState,
     ) -> impl Future<Output = fdo::Result<bool>> + Send {
         async { Ok(false) }
     }
@@ -327,7 +327,12 @@ impl<T: IBusEngine + 'static> Engine<T> {
         // Note: ibuskeysyms-update.pl indicates that IBUS_KEY_* constants are the same as XK_
         // constants provided by xkeysym
         self.e
-            .process_key_event(sc, keyval.into(), keycode.into(), state)
+            .process_key_event(
+                sc,
+                keyval.into(),
+                keycode.into(),
+                IBusModifierState::new_with_raw_value(state),
+            )
             .await
     }
 

--- a/src/ibus/engine.rs
+++ b/src/ibus/engine.rs
@@ -4,16 +4,22 @@ use std::future::Future;
 use std::marker::Send;
 
 use log::info;
+use xkeysym::{KeyCode, Keysym};
 use zbus::{fdo, interface, zvariant::Value, Connection, SignalContext};
 
-/// Implement this trait to implement a input method
+use super::{ibus_serde::make_ibus_text, LookupTable};
+
+/// Implement this trait to implement an input method
+///
+/// Your implementation can use the methods of the [`IBusEngineBackend`]
+/// to display text to the user.
 pub trait IBusEngine: Send + Sync {
     /// 键盘按键消息
     fn process_key_event(
         &mut self,
         _sc: SignalContext<'_>,
-        _keyval: u32,
-        _keycode: u32,
+        _keyval: Keysym,
+        _keycode: KeyCode,
         _state: u32,
     ) -> impl Future<Output = fdo::Result<bool>> + Send {
         async { Ok(false) }
@@ -103,11 +109,100 @@ pub trait IBusEngine: Send + Sync {
     }
 }
 
+#[derive(Debug, Copy, Clone, PartialEq, PartialOrd, Ord, Eq)]
+pub enum IBusPreeditFocusMode {
+    Clear,
+    Commit,
+}
+
+impl From<IBusPreeditFocusMode> for u32 {
+    fn from(value: IBusPreeditFocusMode) -> Self {
+        match value {
+            IBusPreeditFocusMode::Clear => 0,
+            IBusPreeditFocusMode::Commit => 1,
+        }
+    }
+}
+
+/// Methods that the IBus daemon provides for inputs methods to use
+pub trait IBusEngineBackend: IBusEngine + 'static {
+    /// Type this text on behalf of the user
+    fn commit_text(
+        sc: &SignalContext<'_>,
+        text: String,
+    ) -> impl std::future::Future<Output = zbus::Result<()>> + Send;
+    /// Show of hide this lookup table
+    fn update_lookup_table(
+        sc: &SignalContext<'_>,
+        table: &LookupTable,
+        visible: bool,
+    ) -> impl std::future::Future<Output = zbus::Result<()>> + Send;
+    /// Sets the preedit text.
+    ///
+    /// The preedit text is a piece of text displayed in the place where text is to be written, but
+    /// not written yet, in the sense that the underlying application is not aware of it.
+    ///
+    /// cursor_pos is a value from 0 to `text.len()` indicating where the cursor should be
+    /// displayed.
+    fn update_preedit_text(
+        sc: &SignalContext<'_>,
+        text: String,
+        cursor_pos: u32,
+        visible: bool,
+        mode: IBusPreeditFocusMode,
+    ) -> impl std::future::Future<Output = zbus::Result<()>> + Send;
+    /// Sets the auxiliary text
+    ///
+    /// The auxiliary text is a text shown in a floating textbox besides the place where text is
+    /// to be written.
+    fn update_auxiliary_text(
+        sc: &SignalContext<'_>,
+        text: String,
+        visible: bool,
+    ) -> impl std::future::Future<Output = zbus::Result<()>> + Send;
+}
+
+impl<T: IBusEngine + 'static> IBusEngineBackend for T {
+    async fn commit_text(sc: &SignalContext<'_>, text: String) -> zbus::Result<()> {
+        Engine::<Self>::commit_text(sc, make_ibus_text(text)).await
+    }
+    async fn update_lookup_table(
+        sc: &SignalContext<'_>,
+        table: &LookupTable,
+        visible: bool,
+    ) -> zbus::Result<()> {
+        Engine::<Self>::update_lookup_table(sc, table.serialize(), visible).await
+    }
+    async fn update_preedit_text(
+        sc: &SignalContext<'_>,
+        text: String,
+        cursor_pos: u32,
+        visible: bool,
+        mode: IBusPreeditFocusMode,
+    ) -> zbus::Result<()> {
+        Engine::<Self>::update_preedit_text(
+            sc,
+            make_ibus_text(text),
+            cursor_pos,
+            visible,
+            mode.into(),
+        )
+        .await
+    }
+    async fn update_auxiliary_text(
+        sc: &SignalContext<'_>,
+        text: String,
+        visible: bool,
+    ) -> zbus::Result<()> {
+        Engine::<Self>::update_auxiliary_text(sc, make_ibus_text(text), visible).await
+    }
+}
+
 /// D-Bus interface: `org.freedesktop.IBus.Engine`
 ///
 /// <https://ibus.github.io/docs/ibus-1.5/IBusEngine.html>
 #[derive(Debug, Clone)]
-pub struct Engine<T: IBusEngine + 'static> {
+pub(crate) struct Engine<T: IBusEngine + 'static> {
     e: T,
 
     _op: String,
@@ -229,7 +324,11 @@ impl<T: IBusEngine + 'static> Engine<T> {
         keycode: u32,
         state: u32,
     ) -> fdo::Result<bool> {
-        self.e.process_key_event(sc, keyval, keycode, state).await
+        // Note: ibuskeysyms-update.pl indicates that IBUS_KEY_* constants are the same as XK_
+        // constants provided by xkeysym
+        self.e
+            .process_key_event(sc, keyval.into(), keycode.into(), state)
+            .await
     }
 
     async fn set_cursor_location(
@@ -367,7 +466,7 @@ impl<T: IBusEngine + 'static> Engine<T> {
     }
 
     #[zbus(signal)]
-    pub async fn commit_text(sc: &SignalContext<'_>, text: Value<'_>) -> zbus::Result<()>;
+    async fn commit_text(sc: &SignalContext<'_>, text: Value<'_>) -> zbus::Result<()>;
 
     // 忽略 (用户界面相关)
     #[zbus(signal)]
@@ -389,7 +488,7 @@ impl<T: IBusEngine + 'static> Engine<T> {
 
     // 忽略 (用户界面相关)
     #[zbus(signal)]
-    pub async fn update_lookup_table(
+    async fn update_lookup_table(
         sc: &SignalContext<'_>,
         table: Value<'_>,
         visible: bool,

--- a/src/ibus/ibus_serde.rs
+++ b/src/ibus/ibus_serde.rs
@@ -70,25 +70,6 @@ pub const IBUS_HYPER_MASK: u32 = 1 << 27;
 /// meta 键
 pub const IBUS_META_MASK: u32 = 1 << 28;
 
-// 源文件: `ibus/src/ibuskeysyms.h`
-
-/// 退格键
-pub const IBUS_KEY_BACKSPACE: u32 = 0xff08;
-/// 回车键
-pub const IBUS_KEY_RETURN: u32 = 0xff0d;
-/// ESC
-pub const IBUS_KEY_ESCAPE: u32 = 0xff1b;
-/// 删除键
-pub const IBUS_KEY_DELETE: u32 = 0xffff;
-/// 方向键: 左
-pub const IBUS_KEY_LEFT: u32 = 0xff51;
-/// 方向键: 上
-pub const IBUS_KEY_UP: u32 = 0xff52;
-/// 方向键: 右
-pub const IBUS_KEY_RIGHT: u32 = 0xff53;
-/// 方向键: 下
-pub const IBUS_KEY_DOWN: u32 = 0xff54;
-
 /// 检查按键消息: 是否为按下按键
 pub fn is_keydown(state: u32) -> bool {
     !is_keyup(state)

--- a/src/ibus/lookup_table.rs
+++ b/src/ibus/lookup_table.rs
@@ -1,6 +1,6 @@
 use zbus::zvariant::{Array, Signature, Structure, Value};
 
-use super::make_ibus_text;
+use super::ibus_serde::make_ibus_text;
 
 #[derive(Debug, Copy, Clone)]
 pub enum IBusOrientation {
@@ -65,7 +65,7 @@ impl LookupTable {
         })
     }
 
-    pub fn serialize(&self) -> Value<'static> {
+    pub(crate) fn serialize(&self) -> Value<'static> {
         let special = Array::new(Signature::from_str_unchecked("{sv}"));
         let candidates: Array = self
             .candidates

--- a/src/ibus/mod.rs
+++ b/src/ibus/mod.rs
@@ -15,6 +15,6 @@ pub use bus::IBus;
 pub use engine::{IBusEngine, IBusEngineBackend, IBusPreeditFocusMode};
 pub use error::IBusErr;
 pub use factory::IBusFactory;
-pub use ibus_serde::{is_keydown, is_keyup, is_special_mask};
+pub use ibus_serde::IBusModifierState;
 pub use lookup_table::LookupTable;
 pub use xkeysym;

--- a/src/ibus/mod.rs
+++ b/src/ibus/mod.rs
@@ -12,12 +12,9 @@ mod lookup_table;
 
 pub use addr::get_ibus_addr;
 pub use bus::IBus;
-pub use engine::{Engine, IBusEngine};
+pub use engine::{IBusEngine, IBusEngineBackend, IBusPreeditFocusMode};
 pub use error::IBusErr;
 pub use factory::IBusFactory;
-pub use ibus_serde::{
-    is_keydown, is_keyup, is_special_mask, make_ibus_text, IBUS_KEY_BACKSPACE, IBUS_KEY_DELETE,
-    IBUS_KEY_DOWN, IBUS_KEY_ESCAPE, IBUS_KEY_LEFT, IBUS_KEY_RETURN, IBUS_KEY_RIGHT, IBUS_KEY_UP,
-    IBUS_RELEASE_MASK,
-};
+pub use ibus_serde::{is_keydown, is_keyup, is_special_mask};
 pub use lookup_table::LookupTable;
+pub use xkeysym;

--- a/src/pmim/engine.rs
+++ b/src/pmim/engine.rs
@@ -1,3 +1,4 @@
+use xkeysym::{KeyCode, Keysym};
 use zbus::{fdo, SignalContext};
 
 use super::server::Pmims;
@@ -18,11 +19,13 @@ impl IBusEngine for PmimEngine {
     async fn process_key_event(
         &mut self,
         sc: SignalContext<'_>,
-        keyval: u32,
-        keycode: u32,
+        keyval: Keysym,
+        keycode: KeyCode,
         state: u32,
     ) -> fdo::Result<bool> {
-        self.s.process_key_event(sc, keyval, keycode, state).await
+        self.s
+            .process_key_event(sc, keyval.into(), keycode.into(), state)
+            .await
     }
 
     async fn set_cursor_location(

--- a/src/pmim/engine.rs
+++ b/src/pmim/engine.rs
@@ -2,7 +2,7 @@ use xkeysym::{KeyCode, Keysym};
 use zbus::{fdo, SignalContext};
 
 use super::server::Pmims;
-use crate::ibus::{IBusEngine, IBusFactory};
+use crate::ibus::{IBusEngine, IBusFactory, IBusModifierState};
 
 #[derive(Debug, Clone)]
 pub struct PmimEngine {
@@ -21,10 +21,10 @@ impl IBusEngine for PmimEngine {
         sc: SignalContext<'_>,
         keyval: Keysym,
         keycode: KeyCode,
-        state: u32,
+        state: IBusModifierState,
     ) -> fdo::Result<bool> {
         self.s
-            .process_key_event(sc, keyval.into(), keycode.into(), state)
+            .process_key_event(sc, keyval.into(), keycode.into(), state.raw_value())
             .await
     }
 

--- a/src/pmim/server/at/km.rs
+++ b/src/pmim/server/at/km.rs
@@ -1,11 +1,9 @@
 //! 按键管理器
 use log::debug;
+use xkeysym::key;
 
 use super::super::m::{MSender, Ms, MsT};
-use crate::ibus::{
-    is_keydown, is_special_mask, IBUS_KEY_BACKSPACE, IBUS_KEY_DELETE, IBUS_KEY_DOWN,
-    IBUS_KEY_ESCAPE, IBUS_KEY_LEFT, IBUS_KEY_RETURN, IBUS_KEY_RIGHT, IBUS_KEY_UP,
-};
+use crate::ibus::{is_keydown, is_special_mask};
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 enum 输入状态 {
@@ -33,13 +31,6 @@ pub struct Km {
 }
 
 // 按键 b'' as u32 定义
-const K_A: u32 = b'a' as u32;
-const K_Z: u32 = b'z' as u32;
-const K_A1: u32 = b'A' as u32;
-const K_Z1: u32 = b'Z' as u32;
-const K_0: u32 = b'0' as u32;
-const K_9: u32 = b'9' as u32;
-const KS: u32 = b' ' as u32;
 const KC1: u32 = b'`' as u32;
 const KC2: u32 = b'~' as u32;
 const KC3: u32 = b'!' as u32;
@@ -154,7 +145,7 @@ impl Km {
                 if 按下 {
                     match keyval {
                         // `a` ~ `z`
-                        K_A..=K_Z => {
+                        key::a..=key::z => {
                             // 如果特殊按键同时按下 (Shift, Ctrl, Alt, Super 等)
                             // 忽略按键
                             if !is_special_mask(state) {
@@ -173,7 +164,7 @@ impl Km {
             输入状态::拼音 => match keyval {
                 // 捕捉所有相关按键
                 // `a` ~ `z`
-                K_A..=K_Z => {
+                key::a..=key::z => {
                     捕捉 = true;
                     if 按下 {
                         // 禁用退格的同时, 也禁止输入新的拼音
@@ -184,14 +175,14 @@ impl Km {
                     }
                 }
                 // ESC: 强制退出
-                IBUS_KEY_ESCAPE => {
+                key::Escape => {
                     捕捉 = true;
                     if 按下 {
                         self.清理(false).await;
                     }
                 }
                 // `0` ~ `9`, 空格, Enter
-                K_0..=K_9 | KS | IBUS_KEY_RETURN => {
+                key::_0..=key::_9 | key::space | key::Return => {
                     捕捉 = true;
                     // 如果启用了输入反馈, 忽略按键
                     if 按下 && (!self.ef) {
@@ -202,7 +193,7 @@ impl Km {
                     }
                 }
                 // 退格 (backspace)
-                IBUS_KEY_BACKSPACE => {
+                key::BackSpace => {
                     捕捉 = true;
                     // 如果禁用了退格键, 忽略按键
                     if 按下 && (!self.禁用退格) {
@@ -218,7 +209,7 @@ impl Km {
                     }
                 }
                 // `A` ~ `Z`
-                K_A1..=K_Z1 => {
+                key::A..=key::A => {
                     捕捉 = true;
                     // 忽略按键
                 }
@@ -230,12 +221,12 @@ impl Km {
                     // 忽略按键
                 }
                 // 删除键
-                IBUS_KEY_DELETE => {
+                key::Delete => {
                     捕捉 = true;
                     // 忽略按键
                 }
                 // 光标按键: 上下左右
-                IBUS_KEY_LEFT | IBUS_KEY_RIGHT | IBUS_KEY_UP | IBUS_KEY_DOWN => {
+                key::Left | key::Right | key::Up | key::Down => {
                     捕捉 = true;
                     // 忽略按键
                     debug!("光标: 上下左右");

--- a/src/pmim/server/at/r.rs
+++ b/src/pmim/server/at/r.rs
@@ -4,7 +4,7 @@ use zbus::SignalContext;
 
 use super::super::super::engine::PmimEngine;
 use super::super::m::{Mk, Mr};
-use crate::ibus::{make_ibus_text, Engine};
+use crate::ibus::IBusEngineBackend;
 
 async fn 任务(mut r: mpsc::Receiver<Mr>) {
     // 按键管理器 消息发送端
@@ -19,10 +19,8 @@ async fn 任务(mut r: mpsc::Receiver<Mr>) {
                 // 提交文本 (CommitText)
                 Mr::T(t) => {
                     if let Some(sc) = &sc {
-                        // 调用 IBusEngine 接口
-                        let text = make_ibus_text(t.0);
                         // 忽略错误
-                        let _ = Engine::<PmimEngine>::commit_text(sc, text).await;
+                        let _ = PmimEngine::commit_text(sc, t.0).await;
                     }
                     // 忽略
                 }

--- a/src/pmim/server/m/ms.rs
+++ b/src/pmim/server/m/ms.rs
@@ -1,6 +1,6 @@
 use serde_json::Value;
 
-use crate::ibus::is_keydown;
+use crate::ibus::IBusModifierState;
 
 const MS_S: &'static str = "S";
 const MS_K: &'static str = "K";
@@ -64,7 +64,11 @@ pub struct MsK(pub Vec<u32>);
 
 impl MsK {
     pub fn new(keyval: u32, keycode: u32, state: u32) -> Self {
-        let kd = if is_keydown(state) { 1 } else { 0 };
+        let kd = if IBusModifierState::new_with_raw_value(state).is_keydown() {
+            1
+        } else {
+            0
+        };
         Self(vec![keyval, keycode, state, kd])
     }
 }


### PR DESCRIPTION
This makes the following changes:
- make it so methods provided by IBus to input method engines are methods of the structure implementing IBusEngine directly, instead of through the Engine structure (which is now private)
- make methods of the IBusEngine trait take more ergnomic types:
* String instead of Value with the need to serialize String to Value on each use
* LookupTable instead of Value with the need to serialize manually on each use
* process_key_event takes Keysym, Keycode and a structure instead of three u32 arguments which are easy to confuse

Keysym comes from the xkeysym crate, which also brings all the constants for keys, instead of having to copy them by hand like you did for pmim. I find this very handy.